### PR TITLE
Updated mlp.py

### DIFF
--- a/8- Training a neural network: Implementing back propagation from scratch/code/mlp.py
+++ b/8- Training a neural network: Implementing back propagation from scratch/code/mlp.py
@@ -139,7 +139,7 @@ class MLP(object):
                 sum_errors += self._mse(target, output)
 
             # Epoch complete, report the training error
-            print("Error: {} at epoch {}".format(sum_errors / len(items), i+1))
+            print("Error: {} at epoch {}".format(sum_errors / len(inputs), i+1))
 
         print("Training complete!")
         print("=====")


### PR DESCRIPTION
In the back propagation method, the list 'items' is not accessible and hence the 'len(items)' method will generate an error. The list 'inputs' should be used since it is the one which has been passed as an argument to the method. 