### PR TITLE
[fix] Fix librosa errors in lecture 11 code

### DIFF
--- a/11- Preprocessing audio data for deep learning/code/audio_prep.py
+++ b/11- Preprocessing audio data for deep learning/code/audio_prep.py
@@ -12,7 +12,7 @@ signal, sample_rate = librosa.load(file, sr=22050)
 # WAVEFORM
 # display waveform
 plt.figure(figsize=FIG_SIZE)
-librosa.display.waveplot(signal, sample_rate, alpha=0.4)
+librosa.display.waveshow(signal, sr=sample_rate, alpha=0.4)
 plt.xlabel("Time (s)")
 plt.ylabel("Amplitude")
 plt.title("Waveform")
@@ -78,7 +78,7 @@ plt.title("Spectrogram (dB)")
 
 # MFCCs
 # extract 13 MFCCs
-MFCCs = librosa.feature.mfcc(signal, sample_rate, n_fft=n_fft, hop_length=hop_length, n_mfcc=13)
+MFCCs = librosa.feature.mfcc(y=signal, sr=sample_rate, n_fft=n_fft, hop_length=hop_length, n_mfcc=13)
 
 # display MFCCs
 plt.figure(figsize=FIG_SIZE)


### PR DESCRIPTION
Following fixes were done in light of updated librosa API -

- Update `librosa.display.waveplot` to `librosa.display.waveshow`
- Update positional arguments in MFCC to keyword arguments